### PR TITLE
[FEAT] 입고 관리 기능 전체 구현

### DIFF
--- a/src/controller/IncomingController.java
+++ b/src/controller/IncomingController.java
@@ -1,10 +1,43 @@
 package controller;
 
 
+import java.util.List;
+import service.IncomigService;
+import vo.IncomingVO;
 
 public class IncomingController {
 
-    public static void main(String[] args) {
+    private IncomigService incomigService;
 
+    public IncomingController(IncomigService incomigService) {
+        this.incomigService = incomigService;
+    }
+
+    public List<IncomingVO> getAllIncomingProductsWithDetails() {
+        return incomigService.getAllIncomingProductsWithDetails();
+    }
+
+    public void printAllIncomingProductsWithDetails() {
+        List<IncomingVO> incomings = getAllIncomingProductsWithDetails();
+
+        System.out.printf("%-10s%-12s%-25s%-20s%-16s%-20s%-10s%-10s%-12s%-10s\n",
+                "입고 번호", "입고 상태", "입고 상품 코드", "상품 입고 일자",
+                "입고 종류", "입고 매입처", "입고 수량", "입고 단가", "입고 창고", "입고 구역");
+        System.out.println("--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+
+        for (IncomingVO incoming : incomings) {
+            String incomingDate = incoming.getIncomingProductDate() != null ? incoming.getIncomingProductDate().toString() : "N/A"; // null일 경우 "N/A"로 표시
+            System.out.printf("%-10d%-12s%-26s%-26s%-18s%-26s%-10d%-10d%-16s%-10s\n",
+                    incoming.getIncomingProductSeq(),
+                    incoming.getIncomingProductStatus(),
+                    incoming.getProductCode(),
+                    incomingDate,
+                    incoming.getIncomingProductType(),
+                    incoming.getIncomingProductSupplierName(),
+                    incoming.getIncomingProductCount(),
+                    incoming.getIncomingProductPrice(),
+                    incoming.getWarehouseCode(),
+                    incoming.getZoneCode());
+        }
     }
 }

--- a/src/controller/IncomingController.java
+++ b/src/controller/IncomingController.java
@@ -1,20 +1,37 @@
 package controller;
 
 
+import java.sql.SQLException;
 import java.util.List;
+import java.util.Scanner;
 import service.IncomigService;
 import vo.IncomingVO;
 
 public class IncomingController {
+    Scanner scanner = new Scanner(System.in);
 
-    private IncomigService incomigService;
+    private IncomigService incomingService;
 
-    public IncomingController(IncomigService incomigService) {
-        this.incomigService = incomigService;
+    public IncomingController(IncomigService incomingService) {
+        this.incomingService = incomingService;
     }
 
     public List<IncomingVO> getAllIncomingProductsWithDetails() {
-        return incomigService.getAllIncomingProductsWithDetails();
+        return incomingService.getAllIncomingProductsWithDetails();
+    }
+    public void incomingProductMenu() throws Exception {
+        printAllIncomingProductsWithDetails();
+        System.out.println("관리할 입고 상품의 번호를 입력하세요:");
+        long seq = scanner.nextLong();
+        System.out.println("1. 수정\n2. 승인");
+        System.out.print("선택: ");
+        int manageChoice = scanner.nextInt();
+
+        switch (manageChoice) {
+            case 1 -> updateIncomingProduct(seq, scanner);
+            case 2 -> approveIncomingProduct(seq);
+            default -> System.out.println("옳지 않은 입력입니다.");
+        }
     }
 
     public void printAllIncomingProductsWithDetails() {
@@ -40,4 +57,18 @@ public class IncomingController {
                     incoming.getZoneCode());
         }
     }
+    public void updateIncomingProduct(long seq, Scanner scanner) throws SQLException {
+        System.out.println("수정할 ZONE 코드, 수량, 가격을 입력하세요 (공백으로 구분):");
+        String zoneCode = scanner.next();
+        int count = scanner.nextInt();
+        int price = scanner.nextInt();
+
+        incomingService.updateIncomingProductDetails(seq, zoneCode, count, price);
+        printAllIncomingProductsWithDetails();
+    }
+    public void approveIncomingProduct(long seq) throws Exception {
+        incomingService.approveIncomingProduct(seq);
+        printAllIncomingProductsWithDetails();
+    }
+
 }

--- a/src/controller/IncomingController.java
+++ b/src/controller/IncomingController.java
@@ -1,15 +1,17 @@
 package controller;
 
-
-import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
 import java.util.Scanner;
 import service.IncomigService;
+import vo.DetailedIncomingVO;
 import vo.IncomingVO;
 
 public class IncomingController {
-    Scanner scanner = new Scanner(System.in);
 
+    Scanner scanner = new Scanner(System.in);
     private IncomigService incomingService;
 
     public IncomingController(IncomigService incomingService) {
@@ -19,45 +21,55 @@ public class IncomingController {
     public List<IncomingVO> getAllIncomingProductsWithDetails() {
         return incomingService.getAllIncomingProductsWithDetails();
     }
-    public void incomingProductMenu() throws Exception {
-        printAllIncomingProductsWithDetails();
-        System.out.println("관리할 입고 상품의 번호를 입력하세요:");
-        long seq = scanner.nextLong();
-        System.out.println("1. 수정\n2. 승인");
-        System.out.print("선택: ");
-        int manageChoice = scanner.nextInt();
 
-        switch (manageChoice) {
-            case 1 -> updateIncomingProduct(seq, scanner);
-            case 2 -> approveIncomingProduct(seq);
+    //입고 관리 선택 메뉴
+    public void incomingProductMenu() throws Exception {
+        boolean continueMenu = true;
+        printAllIncomingProductsWithDetails();
+
+        while (continueMenu) {
+
+            System.out.println("1. 조회 필터 선택\n2. 수정\n3. 승인\n4. 메뉴 나가기");
+            System.out.print("선택: ");
+            int manageChoice = scanner.nextInt();
+
+            switch (manageChoice) {
+                case 1 -> selectFilterOption();
+                case 2 -> {
+                    System.out.println("수정할 입고 상품의 번호를 입력하세요:");
+                    long seqToUpdate = scanner.nextLong();
+                    updateIncomingProduct(seqToUpdate);
+                }
+                case 3 -> {
+                    System.out.println("승인할 입고 상품의 번호를 입력하세요:");
+                    long seqToApprove = scanner.nextLong();
+                    approveIncomingProduct(seqToApprove);
+                }
+                case 4 -> continueMenu = false;
+                default -> System.out.println("옳지 않은 입력입니다.");
+            }
+        }
+    }
+
+    //조회 필터 메뉴
+    private void selectFilterOption() throws Exception {
+        System.out.println("조회 필터 선택");
+        System.out.println("1. 전체 조회 \t2. 년 월 조회 \t3. 기간 별 조회 \t4. 상세 조회");
+        System.out.print("선택: ");
+        int filterChoice = scanner.nextInt();
+
+        switch (filterChoice) {
+            case 1 -> printAllIncomingProductsWithDetails();
+            case 2 -> promptForMonthlyIncomingProducts();
+            case 3 -> promptForIncomingProductsByDateRange();
+            case 4 -> promptForDetailedIncomingProduct();
             default -> System.out.println("옳지 않은 입력입니다.");
         }
     }
 
-    public void printAllIncomingProductsWithDetails() {
-        List<IncomingVO> incomings = getAllIncomingProductsWithDetails();
-
-        System.out.printf("%-10s%-12s%-25s%-20s%-16s%-20s%-10s%-10s%-12s%-10s\n",
-                "입고 번호", "입고 상태", "입고 상품 코드", "상품 입고 일자",
-                "입고 종류", "입고 매입처", "입고 수량", "입고 단가", "입고 창고", "입고 구역");
-        System.out.println("--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
-
-        for (IncomingVO incoming : incomings) {
-            String incomingDate = incoming.getIncomingProductDate() != null ? incoming.getIncomingProductDate().toString() : "N/A"; // null일 경우 "N/A"로 표시
-            System.out.printf("%-10d%-12s%-26s%-26s%-18s%-26s%-10d%-10d%-16s%-10s\n",
-                    incoming.getIncomingProductSeq(),
-                    incoming.getIncomingProductStatus(),
-                    incoming.getProductCode(),
-                    incomingDate,
-                    incoming.getIncomingProductType(),
-                    incoming.getIncomingProductSupplierName(),
-                    incoming.getIncomingProductCount(),
-                    incoming.getIncomingProductPrice(),
-                    incoming.getWarehouseCode(),
-                    incoming.getZoneCode());
-        }
-    }
-    public void updateIncomingProduct(long seq, Scanner scanner) throws SQLException {
+    ////////////////////////////////////////////////////////////////
+    //기능 프롬프트
+    public void updateIncomingProduct(long seq) throws Exception {
         System.out.println("수정할 ZONE 코드, 수량, 가격을 입력하세요 (공백으로 구분):");
         String zoneCode = scanner.next();
         int count = scanner.nextInt();
@@ -66,9 +78,155 @@ public class IncomingController {
         incomingService.updateIncomingProductDetails(seq, zoneCode, count, price);
         printAllIncomingProductsWithDetails();
     }
+
     public void approveIncomingProduct(long seq) throws Exception {
         incomingService.approveIncomingProduct(seq);
         printAllIncomingProductsWithDetails();
     }
+
+    private void promptForMonthlyIncomingProducts() throws Exception {
+        System.out.println("년도와 월을 입력하세요 (예: 2023 5):");
+        int year = scanner.nextInt();
+        int month = scanner.nextInt();
+        if (year > 0 && month >= 1 && month <= 12) {
+            printIncomingProductsByMonth(year, month);
+        } else {
+            System.out.println("잘못된 년도 또는 월을 입력하셨습니다. 다시 입력해주세요.");
+            promptForMonthlyIncomingProducts();
+        }
+    }
+
+    private void promptForIncomingProductsByDateRange() throws Exception {
+        System.out.println("시작 날짜와 종료 날짜를 입력하세요 (예: 2023-01-01 2023-01-31):");
+        String startDateStr = scanner.next();
+        String endDateStr = scanner.next();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+        try {
+            LocalDate startDate = LocalDate.parse(startDateStr, formatter);
+            LocalDate endDate = LocalDate.parse(endDateStr, formatter);
+
+            if (startDate.isAfter(endDate)) {
+                System.out.println("시작 날짜가 종료 날짜보다 뒤에 있습니다. 다시 입력해주세요.");
+            } else {
+                printIncomingProductsByDateRange(startDate, endDate);
+            }
+        } catch (DateTimeParseException e) {
+            System.out.println("잘못된 날짜 형식입니다. 올바른 형식(yyyy-MM-dd)으로 입력해주세요.");
+        }
+    }
+
+    private void promptForDetailedIncomingProduct() throws Exception {
+        System.out.println("조회할 입고 상품의 번호를 입력하세요:");
+        long seq = scanner.nextLong();
+        DetailedIncomingVO detailedIncomingProduct = incomingService.getIncomingProductDetailsWithProductInfo(seq);
+        printDetailedIncomingProduct(detailedIncomingProduct);
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //전체 조회
+    public void printAllIncomingProductsWithDetails() throws Exception {
+        List<IncomingVO> incomings = getAllIncomingProductsWithDetails();
+        printIncomingProductsHeader();
+        for (IncomingVO incoming : incomings) {
+            printIncomingProduct(incoming);
+        }
+        System.out.println(
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+
+    }
+
+    private void printIncomingProductsByMonth(int year, int month) throws Exception {
+        List<IncomingVO> incomingProducts = incomingService.getIncomingProductsByMonth(year, month);
+
+        printIncomingProductsHeader();
+        for (IncomingVO incoming : incomingProducts) {
+            printIncomingProduct(incoming);
+        }
+        System.out.println(
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+
+    }
+
+    private void printIncomingProductsByDateRange(LocalDate startDate, LocalDate endDate) throws Exception {
+        List<IncomingVO> incomingProducts = incomingService.getIncomingProductsByDateRange(startDate, endDate);
+
+        printIncomingProductsHeader();
+        for (IncomingVO incoming : incomingProducts) {
+            printIncomingProduct(incoming);
+        }
+        System.out.println(
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+
+    }
+
+    private void printDetailedIncomingProduct(DetailedIncomingVO detailedIncomingProduct) {
+        printDetailedIncomingProductHeader();
+        printDetailedIncomingProductInfo(detailedIncomingProduct);
+    }
+
+    ////////////////////////////////////////////////////////////////
+    //중복 출력 메소드 분리
+    private static void printDetailedIncomingProductInfo(DetailedIncomingVO detailedIncomingProduct) {
+        String incomingDate =
+                detailedIncomingProduct.getIncomingProductDate() != null ? detailedIncomingProduct.getIncomingProductDate()
+                        .toString() : "N/A";
+        String productManufactorDate =
+                detailedIncomingProduct.getProductManufactorDate() != null ? detailedIncomingProduct.getProductManufactorDate()
+                        .toString() : "N/A";
+        System.out.printf("%-10d%-12s%-26s%-26s%-18s%-26s%-10d%-10d%-16s%-10s%-20s%-12d%-16s%-20s%-20s%-20s%-20s\n",
+                detailedIncomingProduct.getIncomingProductSeq(),
+                detailedIncomingProduct.getIncomingProductStatus(),
+                detailedIncomingProduct.getProductCode(),
+                incomingDate,
+                detailedIncomingProduct.getIncomingProductType(),
+                detailedIncomingProduct.getIncomingProductSupplierName(),
+                detailedIncomingProduct.getIncomingProductCount(),
+                detailedIncomingProduct.getIncomingProductPrice(),
+                detailedIncomingProduct.getWarehouseCode(),
+                detailedIncomingProduct.getZoneCode(),
+                detailedIncomingProduct.getProductName(),
+                detailedIncomingProduct.getProductPrice(),
+                detailedIncomingProduct.getProductBrand(),
+                detailedIncomingProduct.getProductOrigin(),
+                detailedIncomingProduct.getProductManufactor(),
+                detailedIncomingProduct.getProductStatus(),
+                productManufactorDate);
+        System.out.println(
+                "---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+    }
+
+    private static void printDetailedIncomingProductHeader() {
+        System.out.printf("%-10s%-12s%-25s%-20s%-16s%-20s%-10s%-10s%-12s%-10s%-20s%-12s%-16s%-20s%-20s%-20s%-20s\n",
+                "입고 번호", "입고 상태", "입고 상품 코드", "상품 입고 일자",
+                "입고 종류", "입고 매입처", "입고 수량", "입고 단가", "입고 창고", "입고 구역",
+                "상품명", "상품가격", "상품 브랜드", "상품 원산지", "생산자", "상품 상태", "생산 일자");
+        System.out.println(
+                "---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+    }
+
+    private void printIncomingProductsHeader() {
+        System.out.printf("%-10s%-12s%-25s%-20s%-16s%-20s%-10s%-10s%-12s%-10s\n",
+                "입고 번호", "입고 상태", "입고 상품 코드", "상품 입고 일자",
+                "입고 종류", "입고 매입처", "입고 수량", "입고 단가", "입고 창고", "입고 구역");
+        System.out.println(
+                "--------------------------------------------------------------------------------------------------------------------------------------------------------------------");
+    }
+
+    private void printIncomingProduct(IncomingVO incoming) {
+        String incomingDate = incoming.getIncomingProductDate() != null ? incoming.getIncomingProductDate().toString() : "N/A";
+        System.out.printf("%-10d%-12s%-26s%-26s%-18s%-26s%-10d%-10d%-16s%-10s\n",
+                incoming.getIncomingProductSeq(),
+                incoming.getIncomingProductStatus(),
+                incoming.getProductCode(),
+                incomingDate,
+                incoming.getIncomingProductType(),
+                incoming.getIncomingProductSupplierName(),
+                incoming.getIncomingProductCount(),
+                incoming.getIncomingProductPrice(),
+                incoming.getWarehouseCode(),
+                incoming.getZoneCode());
+    }
+
 
 }

--- a/src/controller/OrderController.java
+++ b/src/controller/OrderController.java
@@ -10,12 +10,33 @@ import vo.OrderVO;
 public class OrderController {
     private OrderService orderService;
 
-    // Dependency Injection을 통해 OrderServiceImpl 인스턴스를 주입받음
     public OrderController(OrderService orderService) {
         this.orderService = orderService;
     }
 
     public List<OrderVO> getAllOrdersWithDetails() {
         return orderService.getAllOrdersWithDetails();
+    }
+
+    public void printAllOrdersWithDetails() {
+        List<OrderVO> orders = getAllOrdersWithDetails();
+
+        System.out.printf("%-10s%-12s%-25s%-20s%-20s%-16s%-8s%-22s%s\n",
+                "발주 번호", "발주 상태", "발주 상품 공급업체명", "발주 상품 배송예정일",
+                "발주 완료일", "발주 상세 번호", "발주 수량", "발주 상품 코드", "창고 코드");
+        System.out.println("-----------------------------------------------------------------------------------------------------------------------------------------------------------------");
+
+        for (OrderVO order : orders) {
+            System.out.printf("%-10d%-12s%-25s%-20s%-20s%-16d%-8d%-22s%s\n",
+                    order.getOrderSeq(),
+                    order.getOrderStatus(),
+                    order.getIncomingProductSupplierName(),
+                    order.getDeliveryDate(),
+                    order.getOrderCompletionDate() == null ? "            미완료                    " : order.getOrderCompletionDate(),
+                    order.getOrderDetailSeq(),
+                    order.getOrderCnt(),
+                    order.getProductCode(),
+                    order.getWarehouseCode());
+        }
     }
 }

--- a/src/dao/IncomingDAO.java
+++ b/src/dao/IncomingDAO.java
@@ -1,7 +1,9 @@
 package dao;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
+import vo.DetailedIncomingVO;
 import vo.IncomingVO;
 import vo.OrderVO;
 
@@ -9,7 +11,10 @@ public interface IncomingDAO {
     List<IncomingVO> getAllIncomingProductsWithDetails();
     void updateIncomingProduct(long seq, String zoneCode, int count, int price) throws SQLException;
     void approveIncomingProduct(long seq) throws Exception;
+    List<IncomingVO> getIncomingProductsByMonth(int year, int month) throws SQLException;
 
+    List<IncomingVO> getIncomingProductsByDateRange(LocalDate startDate, LocalDate endDate) throws SQLException;
+    DetailedIncomingVO getIncomingProductDetailsWithProductInfo(long seq) throws Exception;
 
 
     }

--- a/src/dao/IncomingDAO.java
+++ b/src/dao/IncomingDAO.java
@@ -1,10 +1,15 @@
 package dao;
 
+import java.sql.SQLException;
 import java.util.List;
 import vo.IncomingVO;
 import vo.OrderVO;
 
 public interface IncomingDAO {
     List<IncomingVO> getAllIncomingProductsWithDetails();
+    void updateIncomingProduct(long seq, String zoneCode, int count, int price) throws SQLException;
+    void approveIncomingProduct(long seq) throws Exception;
 
-}
+
+
+    }

--- a/src/dao/IncomingDAO.java
+++ b/src/dao/IncomingDAO.java
@@ -1,5 +1,10 @@
 package dao;
 
+import java.util.List;
+import vo.IncomingVO;
+import vo.OrderVO;
+
 public interface IncomingDAO {
+    List<IncomingVO> getAllIncomingProductsWithDetails();
 
 }

--- a/src/dao/IncomingDAOImpl.java
+++ b/src/dao/IncomingDAOImpl.java
@@ -1,5 +1,67 @@
 package dao;
 
-public class IncomingDAOImpl implements IncomingDAO{
+        import java.sql.Connection;
+        import java.sql.PreparedStatement;
+        import java.sql.ResultSet;
+        import java.sql.SQLException;
+        import java.sql.Timestamp;
+        import java.util.ArrayList;
+        import java.util.List;
+        import util.DbConnection;
+        import vo.IncomingVO;
 
+public class IncomingDAOImpl implements IncomingDAO{
+    private static IncomingDAOImpl instance;
+
+    private IncomingDAOImpl() {}
+
+    public static synchronized IncomingDAOImpl getInstance() {
+        if (instance == null) {
+            instance = new IncomingDAOImpl();
+        }
+        return instance;
+    }
+
+    public List<IncomingVO> getAllIncomingProductsWithDetails() {
+        List<IncomingVO> incomingProducts = new ArrayList<>();
+        Connection conn = null;
+        PreparedStatement stmt = null;
+        ResultSet rs = null;
+
+        try {
+            conn = DbConnection.getInstance().getConnection();
+            String sql = "SELECT * FROM TB_INCOMING_PRODUCT";
+            stmt = conn.prepareStatement(sql);
+            rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                IncomingVO incomingProduct = new IncomingVO();
+                incomingProduct.setIncomingProductSeq(rs.getLong("PK_INCOMING_PRODUCT_SEQ"));
+                incomingProduct.setIncomingProductStatus(rs.getString("V_INCOMING_PRODUCT_STATUS"));
+                Timestamp incomingProductDateTimestamp = rs.getTimestamp("DT_INCOMING_PRODUCT_DATE");
+                if (incomingProductDateTimestamp != null) {
+                    incomingProduct.setIncomingProductDate(incomingProductDateTimestamp.toLocalDateTime());
+                }                incomingProduct.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
+                incomingProduct.setIncomingProductSupplierName(rs.getString("V_INCOMING_PRODUCT_SUPPLIER_NM"));
+                incomingProduct.setIncomingProductCount(rs.getInt("N_INCOMING_PRODUCT_CNT"));
+                incomingProduct.setIncomingProductPrice(rs.getInt("N_INCOMING_PRODUCT_PRICE"));
+                incomingProduct.setProductCode(rs.getString("V_PRODUCT_CD"));
+                incomingProduct.setWarehouseCode(rs.getString("V_WAREHOUSE_CD"));
+                incomingProduct.setZoneCode(rs.getString("V_ZONE_CD"));
+                incomingProducts.add(incomingProduct);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                if (rs != null) rs.close();
+                if (stmt != null) stmt.close();
+                DbConnection.close();
+            } catch (SQLException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return incomingProducts;
+    }
 }

--- a/src/dao/IncomingDAOImpl.java
+++ b/src/dao/IncomingDAOImpl.java
@@ -5,6 +5,7 @@ package dao;
         import java.sql.ResultSet;
         import java.sql.SQLException;
         import java.sql.Timestamp;
+        import java.time.LocalDateTime;
         import java.util.ArrayList;
         import java.util.List;
         import util.DbConnection;
@@ -63,5 +64,36 @@ public class IncomingDAOImpl implements IncomingDAO{
         }
 
         return incomingProducts;
+    }
+    // 입고 상품 정보 수정
+    public void updateIncomingProduct(long seq, String zoneCode, int count, int price) throws SQLException {
+        String sql = "UPDATE TB_INCOMING_PRODUCT SET V_ZONE_CD = ?, N_INCOMING_PRODUCT_CNT = ?, N_INCOMING_PRODUCT_PRICE = ? WHERE PK_INCOMING_PRODUCT_SEQ = ?";
+
+        try (Connection conn = DbConnection.getInstance().getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setString(1, zoneCode);
+            stmt.setInt(2, count);
+            stmt.setInt(3, price);
+            stmt.setLong(4, seq);
+
+            stmt.executeUpdate();
+        } catch (Exception e) {
+            throw new SQLException("입고 상품 정보 수정 중 오류 발생", e);
+        }
+    }
+
+    // 입고 상품 승인 (상태를 COMPLETE로 변경)
+    public void approveIncomingProduct(long seq) throws Exception {
+        String sql = "UPDATE TB_INCOMING_PRODUCT SET V_INCOMING_PRODUCT_STATUS = 'COMPLETE', DT_INCOMING_PRODUCT_DATE = ? WHERE PK_INCOMING_PRODUCT_SEQ = ?";
+
+        try (Connection conn = DbConnection.getInstance().getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setTimestamp(1, Timestamp.valueOf(LocalDateTime.now()));
+            stmt.setLong(2, seq);
+
+            stmt.executeUpdate();
+        } catch (SQLException e) {
+            throw new SQLException("입고 상품 승인 중 오류 발생", e);
+        }
     }
 }

--- a/src/dao/IncomingDAOImpl.java
+++ b/src/dao/IncomingDAOImpl.java
@@ -1,20 +1,25 @@
 package dao;
 
-        import java.sql.Connection;
-        import java.sql.PreparedStatement;
-        import java.sql.ResultSet;
-        import java.sql.SQLException;
-        import java.sql.Timestamp;
-        import java.time.LocalDateTime;
-        import java.util.ArrayList;
-        import java.util.List;
-        import util.DbConnection;
-        import vo.IncomingVO;
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import util.DbConnection;
+import vo.DetailedIncomingVO;
+import vo.IncomingVO;
 
-public class IncomingDAOImpl implements IncomingDAO{
+public class IncomingDAOImpl implements IncomingDAO {
+
     private static IncomingDAOImpl instance;
 
-    private IncomingDAOImpl() {}
+    private IncomingDAOImpl() {
+    }
 
     public static synchronized IncomingDAOImpl getInstance() {
         if (instance == null) {
@@ -42,7 +47,8 @@ public class IncomingDAOImpl implements IncomingDAO{
                 Timestamp incomingProductDateTimestamp = rs.getTimestamp("DT_INCOMING_PRODUCT_DATE");
                 if (incomingProductDateTimestamp != null) {
                     incomingProduct.setIncomingProductDate(incomingProductDateTimestamp.toLocalDateTime());
-                }                incomingProduct.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
+                }
+                incomingProduct.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
                 incomingProduct.setIncomingProductSupplierName(rs.getString("V_INCOMING_PRODUCT_SUPPLIER_NM"));
                 incomingProduct.setIncomingProductCount(rs.getInt("N_INCOMING_PRODUCT_CNT"));
                 incomingProduct.setIncomingProductPrice(rs.getInt("N_INCOMING_PRODUCT_PRICE"));
@@ -55,8 +61,12 @@ public class IncomingDAOImpl implements IncomingDAO{
             e.printStackTrace();
         } finally {
             try {
-                if (rs != null) rs.close();
-                if (stmt != null) stmt.close();
+                if (rs != null) {
+                    rs.close();
+                }
+                if (stmt != null) {
+                    stmt.close();
+                }
                 DbConnection.close();
             } catch (SQLException e) {
                 e.printStackTrace();
@@ -65,6 +75,7 @@ public class IncomingDAOImpl implements IncomingDAO{
 
         return incomingProducts;
     }
+
     // 입고 상품 정보 수정
     public void updateIncomingProduct(long seq, String zoneCode, int count, int price) throws SQLException {
         String sql = "UPDATE TB_INCOMING_PRODUCT SET V_ZONE_CD = ?, N_INCOMING_PRODUCT_CNT = ?, N_INCOMING_PRODUCT_PRICE = ? WHERE PK_INCOMING_PRODUCT_SEQ = ?";
@@ -96,4 +107,119 @@ public class IncomingDAOImpl implements IncomingDAO{
             throw new SQLException("입고 상품 승인 중 오류 발생", e);
         }
     }
+
+    public List<IncomingVO> getIncomingProductsByMonth(int year, int month) throws SQLException {
+        List<IncomingVO> incomingProducts = new ArrayList<>();
+        String sql = "SELECT * FROM TB_INCOMING_PRODUCT WHERE YEAR(DT_INCOMING_PRODUCT_DATE) = ? AND MONTH(DT_INCOMING_PRODUCT_DATE) = ?";
+        try (Connection conn = DbConnection.getInstance().getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setInt(1, year);
+            stmt.setInt(2, month);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    IncomingVO incomingProduct = new IncomingVO();
+                    incomingProduct.setIncomingProductSeq(rs.getLong("PK_INCOMING_PRODUCT_SEQ"));
+                    incomingProduct.setIncomingProductStatus(rs.getString("V_INCOMING_PRODUCT_STATUS"));
+                    Timestamp incomingProductDateTimestamp = rs.getTimestamp("DT_INCOMING_PRODUCT_DATE");
+                    if (incomingProductDateTimestamp != null) {
+                        incomingProduct.setIncomingProductDate(incomingProductDateTimestamp.toLocalDateTime());
+                    }
+                    incomingProduct.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
+                    incomingProduct.setIncomingProductSupplierName(rs.getString("V_INCOMING_PRODUCT_SUPPLIER_NM"));
+                    incomingProduct.setIncomingProductCount(rs.getInt("N_INCOMING_PRODUCT_CNT"));
+                    incomingProduct.setIncomingProductPrice(rs.getInt("N_INCOMING_PRODUCT_PRICE"));
+                    incomingProduct.setProductCode(rs.getString("V_PRODUCT_CD"));
+                    incomingProduct.setWarehouseCode(rs.getString("V_WAREHOUSE_CD"));
+                    incomingProduct.setZoneCode(rs.getString("V_ZONE_CD"));
+                    incomingProducts.add(incomingProduct);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return incomingProducts;
+    }
+
+    public List<IncomingVO> getIncomingProductsByDateRange(LocalDate startDate, LocalDate endDate) throws SQLException {
+        List<IncomingVO> incomingProducts = new ArrayList<>();
+        String sql = "SELECT * FROM TB_INCOMING_PRODUCT WHERE DT_INCOMING_PRODUCT_DATE BETWEEN ? AND ?";
+        try (Connection conn = DbConnection.getInstance().getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setDate(1, Date.valueOf(startDate));
+            stmt.setDate(2, Date.valueOf(endDate));
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    IncomingVO incomingProduct = new IncomingVO();
+                    incomingProduct.setIncomingProductSeq(rs.getLong("PK_INCOMING_PRODUCT_SEQ"));
+                    incomingProduct.setIncomingProductStatus(rs.getString("V_INCOMING_PRODUCT_STATUS"));
+                    Timestamp incomingProductDateTimestamp = rs.getTimestamp("DT_INCOMING_PRODUCT_DATE");
+                    if (incomingProductDateTimestamp != null) {
+                        incomingProduct.setIncomingProductDate(incomingProductDateTimestamp.toLocalDateTime());
+                    }
+                    incomingProduct.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
+                    incomingProduct.setIncomingProductSupplierName(rs.getString("V_INCOMING_PRODUCT_SUPPLIER_NM"));
+                    incomingProduct.setIncomingProductCount(rs.getInt("N_INCOMING_PRODUCT_CNT"));
+                    incomingProduct.setIncomingProductPrice(rs.getInt("N_INCOMING_PRODUCT_PRICE"));
+                    incomingProduct.setProductCode(rs.getString("V_PRODUCT_CD"));
+                    incomingProduct.setWarehouseCode(rs.getString("V_WAREHOUSE_CD"));
+                    incomingProduct.setZoneCode(rs.getString("V_ZONE_CD"));
+                    incomingProducts.add(incomingProduct);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return incomingProducts;
+    }
+
+    public DetailedIncomingVO getIncomingProductDetailsWithProductInfo(long seq) throws Exception {
+        DetailedIncomingVO detailedIncoming = null;
+        String sql =
+                "SELECT ip.*, p.V_PRODUCT_NM, p.N_PRODUCT_PRICE, p.V_PRODUCT_BRAND, p.V_PRODUCT_ORIGIN, p.V_PRODUCT_MANUFACTOR, p.V_PRODUCT_STATUS, p.D_PRODUCT_MANUFACTOR_DATE, p.V_CATEGORY_CD "
+                        +
+                        "FROM TB_INCOMING_PRODUCT ip " +
+                        "JOIN TB_PRODUCT p ON ip.V_PRODUCT_CD = p.V_PRODUCT_CD " +
+                        "WHERE ip.PK_INCOMING_PRODUCT_SEQ = ?";
+
+        try (Connection conn = DbConnection.getInstance().getConnection();
+                PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setLong(1, seq);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    detailedIncoming = new DetailedIncomingVO();
+
+                    detailedIncoming.setIncomingProductSeq(rs.getLong("PK_INCOMING_PRODUCT_SEQ"));
+                    detailedIncoming.setIncomingProductStatus(rs.getString("V_INCOMING_PRODUCT_STATUS"));
+                    Timestamp incomingProductDateTimestamp = rs.getTimestamp("DT_INCOMING_PRODUCT_DATE");
+                    if (incomingProductDateTimestamp != null) {
+                        detailedIncoming.setIncomingProductDate(incomingProductDateTimestamp.toLocalDateTime());
+                    }
+                    detailedIncoming.setIncomingProductType(rs.getString("V_INCOMING_PRODUCT_TYPE"));
+                    detailedIncoming.setIncomingProductSupplierName(rs.getString("V_INCOMING_PRODUCT_SUPPLIER_NM"));
+                    detailedIncoming.setIncomingProductCount(rs.getInt("N_INCOMING_PRODUCT_CNT"));
+                    detailedIncoming.setIncomingProductPrice(rs.getInt("N_INCOMING_PRODUCT_PRICE"));
+                    detailedIncoming.setProductCode(rs.getString("V_PRODUCT_CD"));
+                    detailedIncoming.setWarehouseCode(rs.getString("V_WAREHOUSE_CD"));
+                    detailedIncoming.setZoneCode(rs.getString("V_ZONE_CD"));
+
+                    detailedIncoming.setProductName(rs.getString("V_PRODUCT_NM"));
+                    detailedIncoming.setProductPrice(rs.getInt("N_PRODUCT_PRICE"));
+                    detailedIncoming.setProductBrand(rs.getString("V_PRODUCT_BRAND"));
+                    detailedIncoming.setProductOrigin(rs.getString("V_PRODUCT_ORIGIN"));
+                    detailedIncoming.setProductManufactor(rs.getString("V_PRODUCT_MANUFACTOR"));
+                    detailedIncoming.setProductStatus(rs.getString("V_PRODUCT_STATUS"));
+                    Timestamp productManufactorDateTimestamp = rs.getTimestamp("D_PRODUCT_MANUFACTOR_DATE");
+                    if (productManufactorDateTimestamp != null) {
+                        detailedIncoming.setProductManufactorDate(productManufactorDateTimestamp.toLocalDateTime());
+                    }
+                    detailedIncoming.setCategoryCode(rs.getString("V_CATEGORY_CD"));
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("데이터베이스 조회 중 예외 발생", e);
+        }
+        return detailedIncoming;
+
+    }
+
 }

--- a/src/service/IncomigService.java
+++ b/src/service/IncomigService.java
@@ -1,9 +1,12 @@
 package service;
 
+import java.sql.SQLException;
 import java.util.List;
 import vo.IncomingVO;
 
 public interface IncomigService {
     List<IncomingVO> getAllIncomingProductsWithDetails();
+    void updateIncomingProductDetails(long seq, String zoneCode, int count, int price) throws SQLException;
+    void approveIncomingProduct(long seq) throws Exception;
 
 }

--- a/src/service/IncomigService.java
+++ b/src/service/IncomigService.java
@@ -1,5 +1,9 @@
 package service;
 
+import java.util.List;
+import vo.IncomingVO;
+
 public interface IncomigService {
+    List<IncomingVO> getAllIncomingProductsWithDetails();
 
 }

--- a/src/service/IncomigService.java
+++ b/src/service/IncomigService.java
@@ -1,12 +1,23 @@
 package service;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
+import vo.DetailedIncomingVO;
 import vo.IncomingVO;
 
 public interface IncomigService {
+
     List<IncomingVO> getAllIncomingProductsWithDetails();
+
     void updateIncomingProductDetails(long seq, String zoneCode, int count, int price) throws SQLException;
+
     void approveIncomingProduct(long seq) throws Exception;
+
+    List<IncomingVO> getIncomingProductsByMonth(int year, int month) throws SQLException;
+
+    List<IncomingVO> getIncomingProductsByDateRange(LocalDate startDate, LocalDate endDate) throws SQLException;
+
+    DetailedIncomingVO getIncomingProductDetailsWithProductInfo(long seq) throws Exception;
 
 }

--- a/src/service/IncomingServiceImpl.java
+++ b/src/service/IncomingServiceImpl.java
@@ -1,5 +1,19 @@
 package service;
 
-public class IncomingServiceImpl {
+import dao.IncomingDAOImpl;
+import java.util.List;
+import vo.IncomingVO;
 
+public class IncomingServiceImpl implements IncomigService {
+    private IncomingDAOImpl incomingDAO;
+
+    // Dependency Injection을 통해 IncomingProductDAOImpl 인스턴스를 주입받음
+    public IncomingServiceImpl(IncomingDAOImpl incomingProductDAO) {
+        this.incomingDAO = incomingProductDAO;
+    }
+
+    @Override
+    public List<IncomingVO> getAllIncomingProductsWithDetails() {
+        return incomingDAO.getAllIncomingProductsWithDetails();
+    }
 }

--- a/src/service/IncomingServiceImpl.java
+++ b/src/service/IncomingServiceImpl.java
@@ -2,10 +2,13 @@ package service;
 
 import dao.IncomingDAOImpl;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
+import vo.DetailedIncomingVO;
 import vo.IncomingVO;
 
 public class IncomingServiceImpl implements IncomigService {
+
     private IncomingDAOImpl incomingDAO;
 
     // Dependency Injection을 통해 IncomingProductDAOImpl 인스턴스를 주입받음
@@ -17,6 +20,8 @@ public class IncomingServiceImpl implements IncomigService {
     public List<IncomingVO> getAllIncomingProductsWithDetails() {
         return incomingDAO.getAllIncomingProductsWithDetails();
     }
+
+    @Override
     public void updateIncomingProductDetails(long seq, String zoneCode, int count, int price) throws SQLException {
         incomingDAO.updateIncomingProduct(seq, zoneCode, count, price);
     }
@@ -26,6 +31,19 @@ public class IncomingServiceImpl implements IncomigService {
         incomingDAO.approveIncomingProduct(seq);
 
     }
+    @Override
+    public List<IncomingVO> getIncomingProductsByMonth(int year, int month) throws SQLException {
+        return incomingDAO.getIncomingProductsByMonth(year, month);
+    }
 
 
+    @Override
+    public List<IncomingVO> getIncomingProductsByDateRange(LocalDate startDate, LocalDate endDate) throws SQLException{
+        return incomingDAO.getIncomingProductsByDateRange(startDate,endDate);
+    }
+
+    @Override
+    public DetailedIncomingVO getIncomingProductDetailsWithProductInfo(long seq) throws Exception {
+        return incomingDAO.getIncomingProductDetailsWithProductInfo(seq);
+    }
 }

--- a/src/service/IncomingServiceImpl.java
+++ b/src/service/IncomingServiceImpl.java
@@ -1,6 +1,7 @@
 package service;
 
 import dao.IncomingDAOImpl;
+import java.sql.SQLException;
 import java.util.List;
 import vo.IncomingVO;
 
@@ -16,4 +17,15 @@ public class IncomingServiceImpl implements IncomigService {
     public List<IncomingVO> getAllIncomingProductsWithDetails() {
         return incomingDAO.getAllIncomingProductsWithDetails();
     }
+    public void updateIncomingProductDetails(long seq, String zoneCode, int count, int price) throws SQLException {
+        incomingDAO.updateIncomingProduct(seq, zoneCode, count, price);
+    }
+
+    @Override
+    public void approveIncomingProduct(long seq) throws Exception {
+        incomingDAO.approveIncomingProduct(seq);
+
+    }
+
+
 }

--- a/src/serviceImpl/WareHouseServiceImpl.java
+++ b/src/serviceImpl/WareHouseServiceImpl.java
@@ -101,6 +101,11 @@ public class WareHouseServiceImpl implements WareHouseService {
 
     }
 
+    @Override
+    public void updateWareHouse() {
+
+    }
+
     public void viewWareHouseByName() throws IOException {
         System.out.println();
         System.out.println("--".repeat(25));

--- a/src/test/OrderMain.java
+++ b/src/test/OrderMain.java
@@ -1,43 +1,50 @@
 package test;
 
+import controller.IncomingController;
 import controller.OrderController;
+import dao.IncomingDAOImpl;
 import dao.OrderDAO;
 import dao.OrderDAOImpl;
-import java.util.List;
+import java.util.Scanner;
+import service.IncomingServiceImpl;
 import service.OrderService;
 import service.OrderServiceImpl;
-import vo.OrderVO;
 
 public class OrderMain {
     public static void main(String[] args) {
-        // OrderDAOImpl 인스턴스 생성
-        OrderDAO orderDAO = OrderDAOImpl.getInstance();
-        // OrderServiceImpl 인스턴스 생성, OrderDAOImpl 주입
-        OrderService orderService = new OrderServiceImpl(orderDAO);
-        // OrderController 인스턴스 생성, OrderServiceImpl 주입
+
+        // DAO 객체 생성
+        IncomingDAOImpl incomingDAO = IncomingDAOImpl.getInstance();
+        OrderDAOImpl orderDAO = OrderDAOImpl.getInstance();
+
+        // 서비스 객체 생성 및 DAO 객체 주입
+        IncomingServiceImpl incomingService = new IncomingServiceImpl(incomingDAO);
+        OrderServiceImpl orderService = new OrderServiceImpl(orderDAO);
+
+
+        // 컨트롤러 객체 생성 및 서비스 객체 주입
+        IncomingController incomingController = new IncomingController(incomingService);
         OrderController orderController = new OrderController(orderService);
 
-        // 모든 주문 정보와 상세 정보 가져오기
-        List<OrderVO> orders = orderController.getAllOrdersWithDetails();
-        // 헤더 출력
-        System.out.printf("%-10s%-12s%-25s%-20s%-20s%-16s%-8s%-22s%s\n",
-                "발주 번호", "발주 상태", "발주 상품 공급업체명", "발주 상품 배송예정일",
-                "발주 완료일", "발주 상세 번호", "발주 수량", "발주 상품 코드", "창고 코드");
-        System.out.println("-----------------------------------------------------------------------------------------------------------------------------------------------------------------");
 
-        // 가져온 주문 정보 출력
-        for (OrderVO order : orders) {
-            System.out.printf("%-10d%-12s%-25s%-20s%-20s%-16d%-8d%-22s%s\n",
-                    order.getOrderSeq(),
-                    order.getOrderStatus(),
-                    order.getIncomingProductSupplierName(),
-                    order.getDeliveryDate(),
-                    order.getOrderCompletionDate() == null ? "            미완료                    " : order.getOrderCompletionDate(),
-                    order.getOrderDetailSeq(),
-                    order.getOrderCnt(),
-                    order.getProductCode(),
-                    order.getWarehouseCode());
+        // 컨트롤러 메소드 테스트
+//        incomingController.printAllIncomingProductsWithDetails();
+//        orderController.printAllOrdersWithDetails();
+
+        Scanner scanner = new Scanner(System.in);
+        System.out.println("SSG WMS SYSTEM MAIN");
+        System.out.println("1. 입고 관리");
+        System.out.println("2. 발주 목록 출력");
+        System.out.print("선택: ");
+        int choice = scanner.nextInt();
+
+        switch (choice) {
+            case 1 -> incomingController.printAllIncomingProductsWithDetails();
+            case 2 -> orderController.printAllOrdersWithDetails();
+            default -> System.out.println("옳지 않은 입력입니다.");
         }
-    }
 
+        scanner.close();
+
+    }
 }

--- a/src/test/OrderMain.java
+++ b/src/test/OrderMain.java
@@ -23,7 +23,8 @@ public class OrderMain {
 
 
         // 컨트롤러 객체 생성 및 서비스 객체 주입
-        IncomingController incomingController = new IncomingController(incomingService);
+        IncomingController incomingController;
+        incomingController = new IncomingController(incomingService);
         OrderController orderController = new OrderController(orderService);
 
 

--- a/src/test/OrderMain.java
+++ b/src/test/OrderMain.java
@@ -11,7 +11,7 @@ import service.OrderService;
 import service.OrderServiceImpl;
 
 public class OrderMain {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
 
         // DAO 객체 생성
         IncomingDAOImpl incomingDAO = IncomingDAOImpl.getInstance();
@@ -39,7 +39,7 @@ public class OrderMain {
         int choice = scanner.nextInt();
 
         switch (choice) {
-            case 1 -> incomingController.printAllIncomingProductsWithDetails();
+            case 1 -> incomingController.incomingProductMenu();
             case 2 -> orderController.printAllOrdersWithDetails();
             default -> System.out.println("옳지 않은 입력입니다.");
         }

--- a/src/vo/DetailedIncomingVO.java
+++ b/src/vo/DetailedIncomingVO.java
@@ -1,0 +1,26 @@
+package vo;
+
+import java.time.LocalDateTime;
+import lombok.Data;
+
+@Data
+public class DetailedIncomingVO {
+    private long incomingProductSeq;
+    private String incomingProductStatus;
+    private LocalDateTime incomingProductDate;
+    private String incomingProductType;
+    private String incomingProductSupplierName;
+    private int incomingProductCount;
+    private int incomingProductPrice;
+    private String productCode;
+    private String warehouseCode;
+    private String zoneCode;
+    private String productName;
+    private int productPrice;
+    private String productBrand;
+    private String productOrigin;
+    private String productManufactor;
+    private String productStatus;
+    private LocalDateTime productManufactorDate;
+    private String categoryCode;
+}


### PR DESCRIPTION
## 📕 제목

## 📗 작업 내용

> 구현 내용 및 작업 했던 내역

- [x] 입고 리스트 전체 조회
- [x] 입고 리스트 월별 조회
- [x] 입고 리스트 기간 조회
- [x] 입고 리스트 선택 상세 조회
- [x] 입고 정보 수정
- [x] 입고 정보 승인
- [x] 메뉴 로직 구현
> 백엔드 이외
- [x] MySQL에서 발주 생성 시 입고 리스트 생성 트리거 구현
- [x] 입고 리스트에서 status가 COMPLETE로 변경 시, 재고 리스트에 추가 트리거 구현

## 📘 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 아직 메뉴 통합 전이기 때문에 메뉴 호출 반복 같은 기능은 고려하지는 않았습니다.